### PR TITLE
Add Transdecoder and fix Stringtie errors

### DIFF
--- a/bin/qc.R
+++ b/bin/qc.R
@@ -35,6 +35,7 @@ theme_set(
 #############################################################################
 args = commandArgs(trailingOnly=TRUE)
 prefix = args[1]
+ANNEXA_version = args[2]
 
 #############################################################################
 # GENE
@@ -398,11 +399,16 @@ ex_count = ggplot(data = exon, aes(x = exon_biotype, fill = paste(exon_biotype, 
 # PDF
 #############################################################################
 pdf(paste0(prefix, ".annexa.qc.pdf"), width = 7, height = 7)
-grid.newpage()
 cover <- textGrob("ANNEXA report",
                   gp = gpar(fontsize = 40,
                             col = "black"))
-grid.draw(cover)
+        
+sub_cover_text <- paste(print(Sys.Date()), paste("ANNEXA version:", ANNEXA_version), sep = "\n")
+sub_cover <- textGrob(sub_cover_text,
+                  gp = gpar(fontsize = 20,
+                            col = "black"))
+
+grid.arrange(cover, sub_cover)
 
 # Gene
 grid.arrange(textGrob(

--- a/bin/stringtie_fix_exon_number.py
+++ b/bin/stringtie_fix_exon_number.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python3
+# Fix exon numbers on negative strand in Stringtie output
+import re
+
+def reverse_exon_numbers(input_file, output_file):
+    current_transcript = None
+    current_strand = None
+    exons = []
+    
+    with open(input_file, 'r') as infile, open(output_file, 'w') as outfile:
+        for line in infile:
+            fields = line.strip().split('\t')
+            
+            if fields[2] == 'transcript':
+                # Write previous transcript's exons if any
+                if current_transcript and exons:
+                    write_exons(outfile, exons, current_strand)
+                    exons = []
+                
+                # Write the transcript line as is
+                outfile.write(line)
+                current_transcript = fields[8].split('transcript_id')[1].split(';')[0].strip(' "')
+                current_strand = fields[6]
+            
+            elif fields[2] == 'exon':
+                exons.append(line)
+            
+            else:
+                # Write any other type of line as is
+                outfile.write(line)
+        
+        # Write the last transcript's exons
+        if exons:
+            write_exons(outfile, exons, current_strand)
+
+def write_exons(outfile, exons, strand):
+    total_exons = len(exons)
+    if strand == '-':
+        for i, exon in enumerate(exons, 1):
+            new_exon = re.sub(r'exon_number "\d+"', f'exon_number "{total_exons - i + 1}"', exon)
+            outfile.write(new_exon)
+    else:
+        for exon in exons:
+            outfile.write(exon)
+
+# Usage
+input_file = 'novel.full.gtf'
+output_file = 'fixed_novel.full.gtf'
+reverse_exon_numbers(input_file, output_file)

--- a/bin/transdecoder_add_exon_to_CDS.py
+++ b/bin/transdecoder_add_exon_to_CDS.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python3
+#Adds missing exon number to the CDS in the final output of Transdecoder
+import argparse
+import re
+
+parser = argparse.ArgumentParser(description='Add exon number to predicted CDS from TransDecoder')
+parser.add_argument('--gff', type=str, required=True,
+                    help='Path to final TransDecoder genome.gff3 output')
+args = parser.parse_args()
+
+def find_exons(GFF):
+    with open(GFF,'r') as input:
+        with open('exon_cds.gff3', 'w') as output:
+            previous_line = input.readline()
+            output.write(previous_line)
+            for line in input:
+                if "\tCDS\t" in line:
+                    match = re.search(r'exon(\d+)', previous_line)
+                    exon_number = match.group(1)
+
+                    string = f";exon_number={exon_number}"
+                    output.write(line.rstrip()+string+"\n")
+
+                    previous_line = line
+                else:
+                    output.write(line)
+                    previous_line = line
+
+if __name__ == "__main__":
+    find_exons(args.gff)

--- a/modules/gffcompare/gffcompare.nf
+++ b/modules/gffcompare/gffcompare.nf
@@ -26,7 +26,8 @@ process GFFCOMPARE {
     -s !{fasta} \
     !{merged_gtf}
 
-    #Reformat the output of gffcompare to correctly match novel isoforms to known genes
+    # Reformat the output of gffcompare to correctly match novel isoforms to known genes
+    # Takes the transcript_id identified by Stringtie and assigns it to reference gene_id
 
     awk 'BEGIN{
         while(getline<"gffcmp.tracking">0){
@@ -39,6 +40,17 @@ process GFFCOMPARE {
     } {
         if ($12 in final){
             $10=final[$12]; print $0} else {print $0}
-    }' !{merged_gtf} | gtf2gtf_cleanall.sh  > extended_annotations.gtf
+    }' !{merged_gtf} | gtf2gtf_cleanall.sh  > extended_annotations_preaclean.gtf
+
+    # Match correct ref_gene_id to gene_id to some overlapping genes in the reference annotation
+
+    awk '{if ($3 == "transcript" && $13=="ref_gene_id" && $10!=$14) {
+        $10 = $14;
+        print $0
+    } else if ($3 == "exon" && $15=="ref_gene_id" && $10!=$16) {
+        $10 = $16;
+        print $0
+    } else {print $0}
+    }' extended_annotations_preaclean.gtf | gtf2gtf_cleanall.sh > extended_annotations.gtf
     '''
 }

--- a/modules/merge_novel.nf
+++ b/modules/merge_novel.nf
@@ -10,7 +10,7 @@ process MERGE_NOVEL {
   file novel_isoforms
 
   output:
-  path "novel.full.gtf"
+  path "novel.full.gtf", emit: novel_full_gtf
 
   """
   cat ${novel_genes} ${novel_isoforms} | GTF.py format > novel.full.gtf

--- a/modules/qc/report.nf
+++ b/modules/qc/report.nf
@@ -14,13 +14,15 @@ process REPORT {
   file "${prefix}.transcript.stats"
   file "${prefix}.exon.stats"
   file "${prefix}.annexa.qc.pdf"
+  path "missing_genes.txt", optional: true
 
+  script:
   """
   qc_gtf.py -gtf ${gtf} \
     -c_gene ${counts_gene} \
     -ref ${ref} \
     -prefix ${prefix} \
     -tx_discovery ${params.tx_discovery}
-  qc.R ${prefix}
+  qc.R ${prefix} ${workflow.manifest.version}
   """
 }

--- a/modules/stringtie/stringtie_workflow.nf
+++ b/modules/stringtie/stringtie_workflow.nf
@@ -1,0 +1,45 @@
+include { STRINGTIE_ASSEMBLE             } from './stringtie_assemble.nf'
+include { STRINGTIE_MERGE                } from './stringtie_merge.nf'
+include { STRINGTIE_QUANTIFY             } from './stringtie_quant.nf'
+include { GFFCOMPARE                     } from '../gffcompare/gffcompare.nf'
+include { SUBREAD_FEATURECOUNTS          } from '../subread/subread_featurecounts.nf'
+include { MERGE_COUNTS                   } from '../merge_stringtie_quant.nf'
+
+workflow STRINGTIE {
+    take:
+    samples
+    input_gtf
+    ref_fa
+
+    main:
+    STRINGTIE_ASSEMBLE(
+        samples, 
+        input_gtf)
+
+    STRINGTIE_MERGE(
+        STRINGTIE_ASSEMBLE.out.stringtie_assemble_gtf.collect(), 
+        input_gtf)
+
+    STRINGTIE_QUANTIFY(
+        samples, 
+        STRINGTIE_MERGE.out.stringtie_merged_gtf)
+
+    GFFCOMPARE(
+        input_gtf, 
+        ref_fa, 
+        STRINGTIE_MERGE.out.stringtie_merged_gtf)
+
+    SUBREAD_FEATURECOUNTS(
+        samples, 
+        GFFCOMPARE.out.stringtie_gtf)
+
+    MERGE_COUNTS(
+        SUBREAD_FEATURECOUNTS.out.gene_counts.collect(), 
+        SUBREAD_FEATURECOUNTS.out.tx_counts.collect())
+
+    emit:
+    extended_annotation = GFFCOMPARE.out.stringtie_gtf
+    gene_counts = MERGE_COUNTS.out.gene_counts
+    tx_counts = MERGE_COUNTS.out.tx_counts
+    ndr = MERGE_COUNTS.out.ndr
+}

--- a/modules/subread/subread_featurecounts.nf
+++ b/modules/subread/subread_featurecounts.nf
@@ -43,19 +43,12 @@ process SUBREAD_FEATURECOUNTS {
         !{bam}
     
     # Remove columns of output to have Bambu-like format
-    #cut -f2,3,4,5,6 --complement o_counts_gene.txt > counts_gene.txt
-    #cut -f2,3,4,5,6 --complement o_counts_transcript.txt > counts_transcript.txt
-
     # Remove first line (command info) to have correct header
-    #sed -i '1d' counts_gene.txt
-    #sed -i '1d' counts_transcript.txt
-    
-    # Same but awk version
     # Select columns, remove first line, restore tab separators
     awk 'NR>1 {printf("\\n%s ",$1); for (i=7;i<=NF;i++){printf("%s ",$i)}}' !{bam.baseName}_o_counts_gene.txt | grep -v -e '^$' | awk -v OFS="\\t" '$1=$1'> !{bam.baseName}_counts_gene.txt 
     awk 'NR>1 {printf("\\n%s ",$1); for (i=7;i<=NF;i++){printf("%s ",$i)}}' !{bam.baseName}_o_counts_transcript.txt | grep -v -e '^$' | awk -v OFS="\\t" '$1=$1' > !{bam.baseName}_counts_transcript.txt
 
-    # Remove .bam from sample name in column header
+    # Remove .bam from sample name in header
     sed -i "s/\\.bam//" !{bam.baseName}_counts_gene.txt
     sed -i "s/\\.bam//" !{bam.baseName}_counts_transcript.txt
     '''

--- a/modules/transdecoder/convert_to_gtf.nf
+++ b/modules/transdecoder/convert_to_gtf.nf
@@ -1,0 +1,28 @@
+process AGAT_CONVERTSPGFF2GTF {
+    conda (params.enable_conda ? "bioconda::agat=1.4.0" : null)
+    container "${ workflow.containerEngine == 'singularity' ?
+        'https://depot.galaxyproject.org/singularity/agat:1.4.0--pl5321hdfd78af_0' :
+        'biocontainers/agat:1.4.0--pl5321hdfd78af_0' }"
+    cpus params.maxCpu
+    memory params.maxMemory
+
+    input:
+    path gff3
+
+    output:
+    path 'converted_transdecoder.gtf', emit: td_gtf
+
+    script:
+    """
+    agat_convert_sp_gff2gtf.pl \
+        --gff ${gff3} \
+        --gtf_version 3 \
+        --output exon_cds.gtf
+
+    # Remove redundant information from gtf
+    sed -i 's/ID "\\(.*\\)\\.exon\\([0-9]*\\)"/exon_number "\\2"/g' exon_cds.gtf
+
+    # Remove exons (already present in Stringtie output)
+    awk '\$3=="CDS" || \$3=="five_prime_utr" || \$3=="three_prime_utr"' exon_cds.gtf > converted_transdecoder.gtf
+    """
+}

--- a/modules/transdecoder/format_transdecoder.nf
+++ b/modules/transdecoder/format_transdecoder.nf
@@ -1,0 +1,30 @@
+process FORMAT_TRANSDECODER {
+  conda (params.enable_conda ? "conda-forge::python=3.10.4" : null)
+  container "${ workflow.containerEngine == 'singularity' ? 
+                'https://depot.galaxyproject.org/singularity/python:3.10.4' : 
+                'quay.io/biocontainers/python:3.10.4' }"
+  publishDir "$params.outdir/final", mode: 'copy'
+
+  input:
+  path td_gff
+  path novel_full_gtf
+
+  output:
+  path 'exon_cds.gff3', emit: exon_gff3
+  path 'fixed_novel.full.gtf', emit: fixed_novel
+
+  script:
+  """
+    ### Transdecoder output
+    # Restore exon_number in CDS and create exon_cds.gff3
+    transdecoder_add_exon_to_CDS.py --gff ${td_gff}
+
+    # Remove redundant information from final gff3 in gene_name and transcript_id
+    sed -i 's/\\^[^ ]*/;/' exon_cds.gff3
+    sed -i 's/\\.p[0-9]//'g exon_cds.gff3
+
+    ### Stringtie output
+    # Correct exon number in Stringtie output and merge new CDS
+    stringtie_fix_exon_number.py ${novel_full_gtf} fixed_novel.full.gtf
+  """
+}

--- a/modules/transdecoder/merge_and_sort.nf
+++ b/modules/transdecoder/merge_and_sort.nf
@@ -1,0 +1,27 @@
+process GTFSORT {
+    conda (params.enable_conda ? "bioconda::gtfsort=0.2.2" : null)
+    container "${ workflow.containerEngine == 'singularity' ?
+        'https://depot.galaxyproject.org/singularity/gtfsort:0.2.2--h4ac6f70_0':
+        'biocontainers/gtfsort:0.2.2--h4ac6f70_0' }"
+    publishDir "$params.outdir/transdecoder", mode: 'copy'
+    cpus params.maxCpu
+    memory params.maxMemory
+
+    input:
+    path fixed_novel
+    path exon_cds
+
+    output:
+    path "novel_CDS.gtf", emit: gtf
+
+    script:
+    """
+    # Merge
+    cat ${fixed_novel} ${exon_cds} > merged.gtf
+
+    gtfsort \
+        -i merged.gtf \
+        -o novel_CDS.gtf \
+        -t ${params.maxCpu}
+    """
+}

--- a/modules/transdecoder/transdecoder_predict.nf
+++ b/modules/transdecoder/transdecoder_predict.nf
@@ -1,0 +1,46 @@
+process TRANSDECODER_PREDICT {
+    conda (params.enable_conda ? "bioconda::transdecoder=5.5.0" : null)
+    container "${ workflow.containerEngine == 'singularity' ?
+        'https://depot.galaxyproject.org/singularity/transdecoder:5.5.0--pl5262hdfd78af_4' :
+        'quay.io/comp-bio-aging/transdecoder' }"
+    cpus params.maxCpu
+    memory params.maxMemory
+    
+    input:
+    path novel_full_gtf
+    path fa
+
+    output:
+    path 'novel.fasta.transdecoder.genome.gff3', emit: gff3
+
+    script:
+    """
+    # Filter annotation to protein coding only
+    grep "protein_coding" ${novel_full_gtf} > pt_coding.gtf
+
+    # Construct transcript fasta file from genome
+    gtf_genome_to_cdna_fasta.pl \
+        pt_coding.gtf \
+        ${fa} \
+        > novel.fasta
+    
+    # Convert transcript structure GTF to alignment-GFF3 formatted file
+    gtf_to_alignment_gff3.pl \
+        pt_coding.gtf > novel.gff3
+    
+    # Extract long ORF and predict likely coding regions
+    TransDecoder.LongOrfs \
+        -S \
+        -t novel.fasta
+    
+    TransDecoder.Predict \
+        --single_best_only \
+        -t novel.fasta
+    
+    # Generated genome-based coding region annotation file
+    cdna_alignment_orf_to_genome_orf.pl \
+        novel.fasta.transdecoder.gff3 \
+        novel.gff3 \
+        novel.fasta > novel.fasta.transdecoder.genome.gff3
+    """
+}

--- a/modules/transdecoder/transdecoder_workflow.nf
+++ b/modules/transdecoder/transdecoder_workflow.nf
@@ -1,0 +1,29 @@
+include { TRANSDECODER_PREDICT  } from './transdecoder_predict.nf'
+include { FORMAT_TRANSDECODER   } from './format_transdecoder.nf'
+include { AGAT_CONVERTSPGFF2GTF } from './convert_to_gtf.nf'
+include { GTFSORT               } from './merge_and_sort.nf'
+
+workflow TRANSDECODER {
+    take:
+    novel_full_gtf
+    ref_fa
+
+    main:
+    TRANSDECODER_PREDICT(
+        novel_full_gtf, 
+        ref_fa)
+
+    FORMAT_TRANSDECODER(
+        TRANSDECODER_PREDICT.out.gff3, 
+        novel_full_gtf)
+        
+    AGAT_CONVERTSPGFF2GTF(
+        FORMAT_TRANSDECODER.out.exon_gff3)
+        
+    GTFSORT(
+        AGAT_CONVERTSPGFF2GTF.out.td_gtf, 
+        FORMAT_TRANSDECODER.out.fixed_novel)
+
+    emit:
+    cds_gtf = GTFSORT.out.gtf
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,7 @@ profiles {
       maxCpu = 2
       maxMemory = '8GB'
       tx_discovery = 'stringtie2'
+      filter = true
     }
   }
 


### PR DESCRIPTION
New:
- Added support for Transdecoder
- Added date and ANNEXA version in the cover of the QC pdf

 Fixes and changes:
- Fixed bug where some overlapping genes were not assigned correctly to reference gene id after Gffcompare step
- Implemented way to skip missing genes in counts_gene during QC step (likely duplicated genes in reference annotation) when Stringtie is used
- Created a subworkflow for Stringtie